### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    llet _start_server = meyrin::actix::init_server();
+    let _start_server = meyrin::actix::init_server();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let _start_server = meyrin::actix::init_server();
+    llet _start_server = meyrin::actix::init_server();
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Maherilaza/Meyrin/security/code-scanning/1](https://github.com/Maherilaza/Meyrin/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only checks out code and runs tests, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change ensures that the `GITHUB_TOKEN` is restricted to the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
